### PR TITLE
SWIFT-1057 Add template for use with Vapor toolbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+Packages
+.build
+xcuserdata
+*.xcodeproj
+DerivedData/
+.DS_Store
+.swiftpm

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,39 @@
+// swift-tools-version:5.2
+import PackageDescription
+
+let package = Package(
+    name: "VaporExample",
+    platforms: [
+        .macOS(.v10_15)
+    ],
+    dependencies: [
+        .package(url: "https://github.com/vapor/vapor", .upToNextMajor(from: "4.7.0")),
+        // TODO fix version
+        .package(url: "https://github.com/mongodb/mongodb-vapor", .branch("main")){{#leaf}},
+        .package(url: "https://github.com/vapor/leaf", .upToNextMajor(from: "4.0.0")){{/leaf}}
+    ],
+    targets: [
+        .target(
+            name: "App",
+            dependencies: [
+                .product(name: "Vapor", package: "vapor"),
+                .product(name: "MongoDBVapor", package: "mongodb-vapor"){{#leaf}},
+                .product(name: "Leaf", package: "leaf"){{/leaf}}
+            ],
+            swiftSettings: [
+                // Enable better optimizations when building in Release configuration. Despite the use of the
+                // `.unsafeFlags` construct required by SwiftPM, this flag is recommended for Release builds. See
+                // <https://github.com/swift-server/guides/blob/main/docs/building.md#building-for-production> for details.
+                .unsafeFlags(["-cross-module-optimization"], .when(configuration: .release))
+            ]
+        ),
+        .target(name: "Run", dependencies: [
+            .target(name: "App"),
+            .product(name: "MongoDBVapor", package: "mongodb-vapor")
+        ]),
+        .testTarget(name: "AppTests", dependencies: [
+            .target(name: "App"),
+            .product(name: "XCTVapor", package: "vapor"),
+        ])
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ export MONGODB_URI='connection-string-here'
 
 5. Load some sample data into the database via the MongoDB shell:
 ```
-mongo $MONGODB_URI home --eval "db.kittens.insert([{name:\"roscoe\",color:\"orange\"},{name:\"chester\",color:\"tan\"}])"
+mongo $MONGODB_URI home --eval "db.kittens.insert([{name:\"roscoe\",color:\"orange\", createdAt: new Date()},{name:\"chester\",color:\"tan\", createdAt: new Date()}])"
 ```
 
 If using Atlas, you could also do this via [Atlas Data Explorer](https://docs.atlas.mongodb.com/data-explorer/).

--- a/README.md
+++ b/README.md
@@ -8,31 +8,40 @@ vapor new MyProject --template https://github.com/mongodb/mongodb-vapor-template
 ## Getting Started
 1. Install [Vapor Toolbox](https://github.com/vapor/toolbox). Installation instructions can be found [here for macOS](https://docs.vapor.codes/4.0/install/macos/#install-toolbox) and [here for Linux](https://docs.vapor.codes/4.0/install/linux/#install-toolbox).
 
-2. [Install MongoDB](https://docs.mongodb.com/manual/installation/), and start up a standalone server locally (this will run on the default host/port, localhost:27017):
+2. Initialize a new project from the command line, and move into the project directory:
+```
+vapor new MyProject --template https://github.com/mongodb/mongodb-vapor-template/
+cd MyProject
+```
+
+3. Set up a MongoDB deployment to connect to. You can [install MongoDB](https://docs.mongodb.com/manual/installation/), and (in a new terminal window) start up a standalone server locally (this will run on the default host/port, `localhost:27017`):
 ```
 mongod --dbpath /data/path/here
 ```
 
-3. Load some sample data into the database:
+Alternatively, you can use [MongoDB Atlas](https://www.mongodb.com/cloud/atlas) to set up a fully managed MongoDB deployment in the cloud.
+
+4. If using Atlas, or a local host/port besides the default `localhost:27017`, set your MongoDB connection string via environment variable:
 ```
-mongo home --eval "db.kittens.insert([{name:\"roscoe\",color:\"orange\"},{name:\"chester\",color:\"tan\"}])"
+export MONGODB_URI='connection-string-here'
 ```
 
-4. Initialize a new project from the command line:
+5. Load some sample data into the database via the MongoDB shell:
 ```
-vapor new MyProject --template https://github.com/mongodb/mongodb-vapor-template/
+mongo $MONGODB_URI home --eval "db.kittens.insert([{name:\"roscoe\",color:\"orange\"},{name:\"chester\",color:\"tan\"}])"
 ```
 
-5. Move into the project directory, and build and run the application (this might take a while on the first time):
+If using Atlas, you could also do this via [Atlas Data Explorer](https://docs.atlas.mongodb.com/data-explorer/).
+
+6. Build and run the application (this might take a while on the first time):
 ```
-cd MyProject
 swift build
 swift run
 ```
 
-5. If using Leaf, go to `http://localhost:8080` to see your app in action and load a list of kittens! Else, you can run `curl http://localhost:8080` to see the resulting JSON.
+7. If using Leaf, go to `http://localhost:8080` to see your app in action and load a list of kittens! Else, you can run `curl http://localhost:8080` to see the resulting JSON.
 
-6. To add a new kitten: if using Leaf, use the form at `http://localhost:8080`. Else, you can
+8. To add a new kitten: if using Leaf, use the form at `http://localhost:8080`. Else, you can
 add new data via `curl`: `curl -d "name=Bob&color=white" http://localhost:8080`. 
 ## Resources:
 * [MongoDBVapor README](https://github.com/mongodb/mongodb-vapor#readme)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
 # mongodb-vapor-template
+
+This repository contains a template which can be used for generating new projects using MongoDB and Vapor via [MongoDBVapor](https://github.com/mongodb/mongodb-vapor) with Vapor's command line tool, [Vapor Toolbox](https://github.com/vapor/toolbox):
+
+```
+vapor new MyProject --template https://github.com/mongodb/mongodb-vapor-template/
+```
+## Getting Started
+1. Install [Vapor Toolbox](https://github.com/vapor/toolbox). Installation instructions can be found [here for macOS](https://docs.vapor.codes/4.0/install/macos/#install-toolbox) and [here for Linux](https://docs.vapor.codes/4.0/install/linux/#install-toolbox).
+
+2. [Install MongoDB](https://docs.mongodb.com/manual/installation/), and start up a standalone server locally (this will run on the default host/port, localhost:27017):
+```
+mongod --dbpath /data/path/here
+```
+
+3. Initialize a new project from the command line:
+```
+vapor new MyProject --template https://github.com/mongodb/mongodb-vapor-template/
+```
+
+4. Move into the project directory, and build and run the application (this might take a while on the first time):
+```
+cd MyProject
+swift build
+swift run
+```
+
+5. Open `http://localhost:8080` to see your app in action!
+
+## Resources:
+* [MongoDBVapor README](https://github.com/mongodb/mongodb-vapor#readme)
+* [MongoDBVapor API documentation](https://mongodb.github.io/mongodb-vapor/)
+* [MongoDB + Vapor example application](https://github.com/mongodb/mongo-swift-driver/tree/main/Examples/VaporExample)
+* [Vapor documentation](https://docs.vapor.codes/4.0/)
+* [MongoDB server documentation](https://docs.mongodb.com/manual/)
+
+## Get in Touch
+Notice any issues with this template, or have ideas for how to make it more useful? Feel free to open a pull request or GitHub issue, or reach out to us on the [SWIFT Jira project](jira.mongodb.org/browse/SWIFT).

--- a/README.md
+++ b/README.md
@@ -13,20 +13,27 @@ vapor new MyProject --template https://github.com/mongodb/mongodb-vapor-template
 mongod --dbpath /data/path/here
 ```
 
-3. Initialize a new project from the command line:
+3. Load some sample data into the database:
+```
+mongo home --eval "db.kittens.insert([{name:\"roscoe\",color:\"orange\"},{name:\"chester\",color:\"tan\"}])"
+```
+
+4. Initialize a new project from the command line:
 ```
 vapor new MyProject --template https://github.com/mongodb/mongodb-vapor-template/
 ```
 
-4. Move into the project directory, and build and run the application (this might take a while on the first time):
+5. Move into the project directory, and build and run the application (this might take a while on the first time):
 ```
 cd MyProject
 swift build
 swift run
 ```
 
-5. Open `http://localhost:8080` to see your app in action!
+5. If using Leaf, go to `http://localhost:8080` to see your app in action and load a list of kittens! Else, you can run `curl http://localhost:8080` to see the resulting JSON.
 
+6. To add a new kitten: if using Leaf, use the form at `http://localhost:8080`. Else, you can
+add new data via `curl`: `curl -d "name=Bob&color=white" http://localhost:8080`. 
 ## Resources:
 * [MongoDBVapor README](https://github.com/mongodb/mongodb-vapor#readme)
 * [MongoDBVapor API documentation](https://mongodb.github.io/mongodb-vapor/)

--- a/README.md
+++ b/README.md
@@ -14,34 +14,36 @@ vapor new MyProject --template https://github.com/mongodb/mongodb-vapor-template
 cd MyProject
 ```
 
-3. Set up a MongoDB deployment to connect to. You can [install MongoDB](https://docs.mongodb.com/manual/installation/), and (in a new terminal window) start up a standalone server locally (this will run on the default host/port, `localhost:27017`):
+3. **If you're using Linux** The driver vendors and wraps the MongoDB C driver (`libmongoc`), which depends on a number of external C libraries when built in Linux environments. As a result, these libraries must be installed on your system in order to build the driver. To install those libraries, please follow the [instructions](http://mongoc.org/libmongoc/current/installing.html#prerequisites-for-libmongoc) from `libmongoc`'s documentation.
+
+4. Set up a MongoDB deployment to connect to. You can [install MongoDB](https://docs.mongodb.com/manual/installation/), and (in a new terminal window) start up a standalone server locally (this will run on the default host/port, `localhost:27017`):
 ```
 mongod --dbpath /data/path/here
 ```
 
 Alternatively, you can use [MongoDB Atlas](https://www.mongodb.com/cloud/atlas) to set up a fully managed MongoDB deployment in the cloud.
 
-4. If using Atlas, or a local host/port besides the default `localhost:27017`, set your MongoDB connection string via environment variable:
+5. If using Atlas, or a local host/port besides the default `localhost:27017`, set your MongoDB connection string via environment variable:
 ```
 export MONGODB_URI='connection-string-here'
 ```
 
-5. Load some sample data into the database via the MongoDB shell:
+6. Load some sample data into the database via the MongoDB shell:
 ```
 mongo $MONGODB_URI home --eval "db.kittens.insert([{name:\"roscoe\",color:\"orange\", createdAt: new Date()},{name:\"chester\",color:\"tan\", createdAt: new Date()}])"
 ```
 
 If using Atlas, you could also do this via [Atlas Data Explorer](https://docs.atlas.mongodb.com/data-explorer/).
 
-6. Build and run the application (this might take a while on the first time):
+7. Build and run the application (this might take a while on the first time):
 ```
 swift build
 swift run
 ```
 
-7. If using Leaf, go to `http://localhost:8080` to see your app in action and load a list of kittens! Else, you can run `curl http://localhost:8080` to see the resulting JSON.
+8. If using Leaf, go to `http://localhost:8080` to see your app in action and load a list of kittens! Else, you can run `curl http://localhost:8080` to see the resulting JSON.
 
-8. To add a new kitten: if using Leaf, use the form at `http://localhost:8080`. Else, you can
+9. To add a new kitten: if using Leaf, use the form at `http://localhost:8080`. Else, you can
 add new data via `curl`: `curl -d "name=Bob&color=white" http://localhost:8080`. 
 ## Resources:
 * [MongoDBVapor README](https://github.com/mongodb/mongodb-vapor#readme)

--- a/Resources/Views/index.leaf
+++ b/Resources/Views/index.leaf
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <title>Kittens</title>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+  <script src="https://unpkg.com/bson@^4/dist/bson.browser.umd.js"></script>
 </head>
 <body>
   
@@ -41,7 +42,12 @@
     $("\#add-btn").click(() => {
       var name = $("\#name").val();
       var color = $("\#color").val();
-      var data = JSON.stringify({
+      // Serialize request data to extended JSON. We use extended JSON
+      // both here, and for serializing/deserializing request data on
+      // the backend, in order to ensure all MongoDB type information
+      // is preserved.
+      // See: https://docs.mongodb.com/manual/reference/mongodb-extended-json
+      var data = EJSON.stringify({
         'name': name,
         'color': color
       })

--- a/Resources/Views/index.leaf
+++ b/Resources/Views/index.leaf
@@ -13,11 +13,13 @@
 <tr>
     <th>Name</th>
     <th>Color</th>
+    <th>Created</th>
 </tr>
 #for(kitten in kittens):
  <tr>
      <td>#(kitten.name)</td>
      <td>#(kitten.color)</td>
+     <td>>#date(kitten.createdAt, "MM-dd-y HH:mm")</td>
  </tr>
 #endfor   
 </table>

--- a/Resources/Views/index.leaf
+++ b/Resources/Views/index.leaf
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Kittens</title>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+</head>
+<body>
+  
+  <h1>Kittens 🐱🐱</h1>
+<table>
+<tr>
+    <th>Name</th>
+    <th>Color</th>
+</tr>
+#for(kitten in kittens):
+ <tr>
+     <td>#(kitten.name)</td>
+     <td>#(kitten.color)</td>
+ </tr>
+#endfor   
+</table>
+<br>
+<br>
+<h2>Add a new kitten</h2>
+<form onsubmit="return false;">
+    <div>
+    <label for="name">Name</label>
+    <input name="name" id="name">
+  </div>
+  <div>
+    <label for="color">Color</label>
+    <input name="color" id="color">
+  <div>
+    <button id="add-btn">Add</button>
+  </div>
+</form>
+
+<script type="text/javascript">
+  $(document).ready(() => {
+    $("\#add-btn").click(() => {
+      var name = $("\#name").val();
+      var color = $("\#color").val();
+      var data = JSON.stringify({
+        'name': name,
+        'color': color
+      })
+      $.ajax({
+          type:'POST',
+          contentType : 'application/json',
+          url:'/',
+          data: data,
+          success: () => {
+            window.location.href = '/';
+          },
+          error: (req, status, message) => {
+            alert("Error: " + message);
+          }
+      });
+    });
+  });
+</script>
+
+</body>
+</html>

--- a/Resources/Views/index.leaf
+++ b/Resources/Views/index.leaf
@@ -47,7 +47,7 @@
       // the backend, in order to ensure all MongoDB type information
       // is preserved.
       // See: https://docs.mongodb.com/manual/reference/mongodb-extended-json
-      var data = EJSON.stringify({
+      var data = BSON.EJSON.stringify({
         'name': name,
         'color': color
       })

--- a/Resources/Views/index.leaf
+++ b/Resources/Views/index.leaf
@@ -19,7 +19,7 @@
  <tr>
      <td>#(kitten.name)</td>
      <td>#(kitten.color)</td>
-     <td>>#date(kitten.createdAt, "MM-dd-y HH:mm")</td>
+     <td>#date(kitten.createdAt, "MM-dd-y HH:mm")</td>
  </tr>
 #endfor   
 </table>

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -1,0 +1,23 @@
+{{#leaf}}import Leaf
+{{/leaf}}import MongoDBVapor
+import Vapor
+
+/// Configures the application.
+public func configure(_ app: Application) throws {
+    // Uncomment to serve files from the /Public folder.
+    // app.middleware.use(FileMiddleware(publicDirectory: app.directory.publicDirectory))
+    {{#leaf}}
+    // Use LeafRenderer for views.
+    app.views.use(.leaf)
+    {{/leaf}}
+    // Use `ExtendedJSONEncoder` and `ExtendedJSONDecoder` for encoding/decoding `Content`. We use extended JSON both
+    // here and on the frontend to ensure all MongoDB type information is correctly preserved.
+    // See: https://docs.mongodb.com/manual/reference/mongodb-extended-json{{#leaf}}
+    // Note that for _encoding_ content, this encoder only gets used for the REST API methods, since Leaf uses its own
+    // custom encoder to encode data for rendering in Leaf views.{{/leaf}}
+    ContentConfiguration.global.use(encoder: ExtendedJSONEncoder(), for: .json)
+    ContentConfiguration.global.use(decoder: ExtendedJSONDecoder(), for: .json)
+
+    // Register routes.
+    try routes(app)
+}

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -3,9 +3,9 @@ import Vapor
 
 /// A type matching the structure of documents in the corresponding MongoDB collection.
 struct Kitten: Content {
-    var _id: BSONObjectID?
-    var name: String
-    var color: String
+    let _id: BSONObjectID?
+    let name: String
+    let color: String
 }
 
 extension Request {

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -6,6 +6,7 @@ struct Kitten: Content {
     let _id: BSONObjectID?
     let name: String
     let color: String
+    var createdAt: Date?
 }
 
 extension Request {
@@ -28,7 +29,8 @@ func routes(_ app: Application) throws {
 
     // A POST request will create a new kitten in the database.
     app.post { req -> EventLoopFuture<Response> in
-        let newKitten = try req.content.decode(Kitten.self)
+        var newKitten = try req.content.decode(Kitten.self)
+        newKitten.createdAt = Date()
         return req.kittenCollection.insertOne(newKitten)
             .map { _ in Response(status: .created) }
     }

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -1,0 +1,35 @@
+import MongoDBVapor
+import Vapor
+
+/// A type matching the structure of documents in the corresponding MongoDB collection.
+struct Kitten: Content {
+    var _id: BSONObjectID?
+    var name: String
+    var color: String
+}
+
+extension Request {
+    /// Convenience accessor for the home.kittens collection.
+    var kittenCollection: MongoCollection<Kitten> {
+        self.mongoDB.client.db("home").collection("kittens", withType: Kitten.self)
+    }
+}
+
+func routes(_ app: Application) throws {
+    // A GET request will return a list of all kittens in the database.{{#leaf}}
+    app.get { req -> EventLoopFuture<View> in{{/leaf}}{{^leaf}}
+    app.get { req -> EventLoopFuture<[Kitten]> in{{/leaf}}
+        req.kittenCollection.find().flatMap { cursor in
+            cursor.toArray()
+        }{{#leaf}}.flatMap { kittens in
+            req.view.render("index.leaf", ["kittens": kittens])
+        }{{/leaf}}
+    }
+
+    // A POST request will create a new kitten in the database.
+    app.post { req -> EventLoopFuture<Response> in
+        let newKitten = try req.content.decode(Kitten.self)
+        return req.kittenCollection.insertOne(newKitten)
+            .map { _ in Response(status: .created) }
+    }
+}

--- a/Sources/Run/main.swift
+++ b/Sources/Run/main.swift
@@ -1,0 +1,23 @@
+import App
+import MongoDBVapor
+import Vapor
+
+var env = try Environment.detect()
+try LoggingSystem.bootstrap(from: &env)
+
+let app = Application(env)
+try configure(app)
+
+// Configure the app to connect to a local MongoDB server running on the default host/port.
+try app.mongoDB.configure("mongodb://localhost:27017")
+
+defer {
+    // Cleanup the application's MongoDB data.
+    app.mongoDB.cleanup()
+    // Clean up the driver's global state. The driver will no longer be usable from this program after this method is
+    // called.
+    cleanupMongoSwift()
+    app.shutdown()
+}
+
+try app.run()

--- a/Sources/Run/main.swift
+++ b/Sources/Run/main.swift
@@ -8,8 +8,9 @@ try LoggingSystem.bootstrap(from: &env)
 let app = Application(env)
 try configure(app)
 
-// Configure the app to connect to a local MongoDB server running on the default host/port.
-try app.mongoDB.configure("mongodb://localhost:27017")
+// Configure the app to connect to a MongoDB deployment. If a connection string is provided via the `MONGODB_URI`
+// environment variable it will be used; otherwise, use the default connection string for a local MongoDB server.
+try app.mongoDB.configure(Environment.get("MONGODB_URI") ?? "mongodb://localhost:27017")
 
 defer {
     // Cleanup the application's MongoDB data.

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -1,0 +1,20 @@
+@testable import App
+import XCTVapor
+
+final class AppTests: XCTestCase {
+    func testFetchKittens() throws {
+        let app = Application(.testing)
+        defer {
+            app.mongoDB.cleanup()
+            app.shutdown()
+        }
+        try configure(app)
+        try app.mongoDB.configure("mongodb://localhost:27017")
+
+        try app.test(.GET, "", afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+            // test that the extended JSON we get can be decoded into `Kitten`s.
+            XCTAssertNoThrow(try res.content.decode([Kitten].self))
+        })
+    }
+}

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -12,9 +12,9 @@ final class AppTests: XCTestCase {
         try app.mongoDB.configure("mongodb://localhost:27017")
 
         try app.test(.GET, "", afterResponse: { res in
-            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.status, .ok){{^leaf}}
             // test that the extended JSON we get can be decoded into `Kitten`s.
-            XCTAssertNoThrow(try res.content.decode([Kitten].self))
+            XCTAssertNoThrow(try res.content.decode([Kitten].self)){{/leaf}}
         })
     }
 }

--- a/manifest.yml
+++ b/manifest.yml
@@ -21,7 +21,8 @@ files:
     files:
       - folder: AppTests
         files:
-          - AppTests.swift
+          - file: AppTests.swift
+            dynamic: true
   - folder: Resources
     if: leaf
     files:

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,32 @@
+name: MongoDB Vapor Template
+variables:
+  - name: leaf
+    description: Would you like to use Leaf?
+    type: bool
+files:
+  - file: Package.swift
+    dynamic: true
+  - folder: Sources
+    files:
+      - folder: Run
+        files:
+          - main.swift
+      - folder: App
+        files:
+          - file: configure.swift
+            dynamic: true
+          - file: routes.swift
+            dynamic: true
+  - folder: Tests
+    files:
+      - folder: AppTests
+        files:
+          - AppTests.swift
+  - folder: Resources
+    if: leaf
+    files:
+      - folder: Views
+        files:
+          - file: index.leaf
+  - .gitignore
+  - README.md


### PR DESCRIPTION
Adds a template for use with Vapor toolbox. Will wait to merge til we do the release so I can fix the version string in Package.swift

To try this out locally, you can run
```
vapor new ProjectName --template https://github.com/mongodb/mongodb-vapor-template --branch SWIFT-1057/vapor-template
```

I will make a follow-up PR to edit the mongodb-vapor README to explain how to use the template. I'll probably just reuse a lot of what I wrote in the README here, but it seems useful to have this README be helpful since it will become the README for any project created via the template.  