### PR TITLE
pin js-bson version

### DIFF
--- a/Resources/Views/index.leaf
+++ b/Resources/Views/index.leaf
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <title>Kittens</title>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
-  <script src="https://unpkg.com/bson@^4/dist/bson.browser.umd.js"></script>
+  <script src="https://unpkg.com/bson@4.4.0/dist/bson.browser.umd.js"></script>
 </head>
 <body>
   


### PR DESCRIPTION
Unfortunately, due to [NODE-3438](https://jira.mongodb.org/browse/NODE-3438) which according to Neal is an issue introduced by one of our dependencies as of 4.4.1, that version of js-bson does not work in the browser.

I don't want to put out the MongoDBVapor release without the template working, so figured we should just pin this for now and we can update it once that issue is resolved. (opened [SWIFT-1264](https://jira.mongodb.org/browse/SWIFT-1264) for this)