### PR TITLE
Move MongoDB.configure call to configure.swift

### DIFF
--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -10,6 +10,10 @@ public func configure(_ app: Application) throws {
     // Use LeafRenderer for views.
     app.views.use(.leaf)
     {{/leaf}}
+    // Configure the app to connect to a MongoDB deployment. If a connection string is provided via the `MONGODB_URI`
+    // environment variable it will be used; otherwise, use the default connection string for a local MongoDB server.
+    try app.mongoDB.configure(Environment.get("MONGODB_URI") ?? "mongodb://localhost:27017")
+
     // Use `ExtendedJSONEncoder` and `ExtendedJSONDecoder` for encoding/decoding `Content`. We use extended JSON both
     // here and on the frontend to ensure all MongoDB type information is correctly preserved.
     // See: https://docs.mongodb.com/manual/reference/mongodb-extended-json{{#leaf}}

--- a/Sources/Run/main.swift
+++ b/Sources/Run/main.swift
@@ -8,10 +8,6 @@ try LoggingSystem.bootstrap(from: &env)
 let app = Application(env)
 try configure(app)
 
-// Configure the app to connect to a MongoDB deployment. If a connection string is provided via the `MONGODB_URI`
-// environment variable it will be used; otherwise, use the default connection string for a local MongoDB server.
-try app.mongoDB.configure(Environment.get("MONGODB_URI") ?? "mongodb://localhost:27017")
-
 defer {
     // Cleanup the application's MongoDB data.
     app.mongoDB.cleanup()


### PR DESCRIPTION
Per Vapor [documentation](https://docs.vapor.codes/4.0/folder-structure/#configureswift), it's best practice to put DB configuration logic in your `configure` method. Making a corresponding PR to mongodb-vapor to reflect this in README